### PR TITLE
Fix: Handle markdown-wrapped JSON responses from Gemini API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import os
 import json
 import sys
+import re
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,6 +9,26 @@ import google.generativeai as genai
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# --- UTILITY FUNCTION: Safe JSON Parser ---
+def parse_json_response(response_text: str):
+    """
+    Safely parse JSON from LLM response, handling markdown code blocks.
+    
+    Handles cases like:
+    - ```json\n{...}\n```
+    - ```\n{...}\n```
+    - {raw JSON}
+    """
+    # Remove markdown code block wrapper if present
+    # Pattern: optional backticks + optional language tag + content + optional backticks
+    json_match = re.search(r'```(?:json)?\s*([\s\S]*?)\s*```', response_text)
+    if json_match:
+        response_text = json_match.group(1).strip()
+    else:
+        response_text = response_text.strip()
+    
+    return json.loads(response_text)
 
 # --- 1. SETUP API KEY ---
 GENAI_KEY = os.getenv("GEMINI_API_KEY")
@@ -120,7 +141,7 @@ async def generate_graph(request: GraphRequest):
     """
     try:
         response_text = get_smart_response(f"{system_prompt}\n\nUSER PROMPT: {request.prompt}", use_json=True)
-        return json.loads(response_text)
+        return parse_json_response(response_text)
     except Exception as e:
         print(f"Error: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,17 +15,23 @@ def parse_json_response(response_text: str):
     """
     Safely parse JSON from LLM response, handling markdown code blocks.
     
+    Only unwraps if the ENTIRE response is a fenced block to avoid breaking
+    valid JSON that contains backticks in field values (e.g., code_snippet).
+    
     Handles cases like:
     - ```json\n{...}\n```
     - ```\n{...}\n```
-    - {raw JSON}
+    - {raw JSON with "field": "```code```"}
     """
-    # Remove markdown code block wrapper if present
-    # Pattern: optional backticks + optional language tag + content + optional backticks
-    json_match = re.search(r'```(?:json)?\s*([\s\S]*?)\s*```', response_text)
-    if json_match:
-        response_text = json_match.group(1).strip()
-    else:
+    response_text = response_text.strip()
+    
+    # Only unwrap if the entire response is wrapped in backticks
+    # This prevents breaking JSON with backticks in field values
+    if response_text.startswith('```') and response_text.endswith('```'):
+        # Remove opening fence (``` or ```json)
+        response_text = re.sub(r'^```(?:json)?\s*', '', response_text)
+        # Remove closing fence (```)
+        response_text = re.sub(r'\s*```$', '', response_text)
         response_text = response_text.strip()
     
     return json.loads(response_text)


### PR DESCRIPTION
##Fixex  #8 

## Description
Fixes a critical issue where Gemini API responses wrapped in markdown code blocks 
(e.g., ```json {...} ```) would cause JSONDecodeError and crash the /generate endpoint 
with a 500 error.

## Root Cause
Even with `response_mime_type: "application/json"` configuration, Gemini occasionally 
wraps JSON responses in markdown code block formatting. The direct `json.loads()` call 
fails to parse this format.

## Solution
Added a `parse_json_response()` utility function that:
- Detects and extracts JSON from markdown code blocks using regex
- Handles multiple markdown variations (with/without language tags)
- Falls back to direct parsing for raw JSON
- Gracefully handles parsing errors with proper exception propagation

## Files Changed
- `backend/main.py`
  - Added `import re`
  - Added `parse_json_response()` utility function
  - Updated `/generate` endpoint to use the new function

## Testing Scenarios Covered
- ✅ Raw JSON responses (backward compatible)
- ✅ ```json {...} ``` format
- ✅ ```{...} ``` format  
- ✅ Responses with extra whitespace
- ✅ Proper error messages on parsing failure

## Impact
- **Reliability:** Eliminates 500 errors from markdown-wrapped responses
- **Compatibility:** Maintains backward compatibility
- **Maintainability:** Reusable utility function for future JSON parsing needs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parsing for the `/generate` endpoint: responses are trimmed and any surrounding Markdown code fences are automatically removed before parsing, making model outputs more reliably processed across varied formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/priyanshu5ingh/VISUALAIZE/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->