### PR TITLE
Fix: Disabled code language change dropdown while regeneration

### DIFF
--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -171,6 +171,7 @@ function EditorContent({ onBack }: EditorProps) {
   const [copied, setCopied] = useState(false);
   const [isListening, setIsListening] = useState(false);
   const [codeLanguage, setCodeLanguage] = useState('Python');
+  const [showLanguageDropDown, setshowLanguageDropDown] = useState(false);
   const [isRegeneratingCode, setIsRegeneratingCode] = useState(false);
   const [chatHistory, setChatHistory] = useState<{role: 'user' | 'ai', text: string}[]>([]);
   const [chatInput, setChatInput] = useState('');
@@ -195,6 +196,7 @@ function EditorContent({ onBack }: EditorProps) {
     setCodeLanguage('Python');
     setChatHistory([]);
     setIsSidebarOpen(false);
+    setshowLanguageDropDown(false);
 
     console.log("🚀 [FRONTEND] Connecting to Backend at:", BACKEND_URL);
 
@@ -239,8 +241,7 @@ function EditorContent({ onBack }: EditorProps) {
     }
   };
 
-  const handleLanguageChange = async (newLang: string) => {
-    if (newLang === codeLanguage || !graphData) return;
+  const regenerateCode = async (newLang: string) => {
     setCodeLanguage(newLang);
     setIsRegeneratingCode(true);
     try {
@@ -250,6 +251,12 @@ function EditorContent({ onBack }: EditorProps) {
       const data = await res.json();
       setGraphData((prev: GraphData | null) => prev ? ({ ...prev, code_snippet: data.code_snippet, code_explanation: data.code_explanation }) : prev);
     } catch (err) { alert("Failed to rewrite code."); } finally { setIsRegeneratingCode(false); }
+  } 
+
+  const handleLanguageChange = async (newLang: string) => {
+    setshowLanguageDropDown(false);
+    if (newLang === codeLanguage || !graphData) return;
+    regenerateCode(newLang);
   };
 
   const handleChatSubmit = async (e: React.FormEvent) => {
@@ -434,17 +441,33 @@ function EditorContent({ onBack }: EditorProps) {
                 {activeTab === 'CODE' && (
                   <div className="h-full flex flex-col">
                     <div className="flex justify-between items-center mb-4">
-                      <div className="relative group">
-                          <button className="flex items-center gap-2 text-xs font-bold text-white bg-slate-800 px-3 py-1.5 rounded-lg border border-white/10 hover:border-blue-500/50 transition-colors">
-                              {codeLanguage} <ChevronDown size={12} />
+                      <div className="relative">
+                        <button className="flex items-center gap-2 text-xs font-bold text-white bg-slate-800 px-3 py-1.5 rounded-lg border border-white/10 hover:border-blue-500/50 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-all" 
+                          onClick={() => setshowLanguageDropDown(p => !p)}
+                        >
+                          {codeLanguage} 
+                          <ChevronDown size={12} className={`transition-transform ${showLanguageDropDown ? 'rotate-180' : ''}`} />
                           </button>
-                          <div className="absolute top-full left-0 mt-2 w-32 bg-slate-900 border border-slate-700 rounded-lg shadow-xl overflow-hidden hidden group-hover:block z-50">
+                        {showLanguageDropDown && (
+                          <>
+                            <div 
+                              className="fixed inset-0 z-40" 
+                              onClick={() => setshowLanguageDropDown(false)} 
+                            />
+                            
+                            <div className="absolute top-full left-0 mt-2 w-32 bg-slate-900 border border-slate-700 rounded-lg shadow-xl overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-100">
                               {['Python', 'JavaScript', 'C++', 'Java'].map(lang => (
-                                  <button key={lang} onClick={() => handleLanguageChange(lang)} className="w-full text-left px-4 py-2 text-xs text-slate-300 hover:bg-blue-600 hover:text-white transition-colors">
+                                <button 
+                                  key={lang} 
+                                  onClick={() => handleLanguageChange(lang)} 
+                                  className="w-full text-left px-4 py-2 text-xs text-slate-300 hover:bg-blue-600 hover:text-white transition-colors first:border-b-0"
+                                >
                                       {lang}
                                   </button>
                               ))}
                           </div>
+                          </>
+                        )}
                       </div>
                       <button onClick={handleCopyCode} className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-xs font-bold transition-colors">
                         {copied ? <Check size={14} /> : <Copy size={14} />} {copied ? 'COPIED' : 'COPY'}

--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -442,8 +442,9 @@ function EditorContent({ onBack }: EditorProps) {
                   <div className="h-full flex flex-col">
                     <div className="flex justify-between items-center mb-4">
                       <div className="relative">
-                        <button className="flex items-center gap-2 text-xs font-bold text-white bg-slate-800 px-3 py-1.5 rounded-lg border border-white/10 hover:border-blue-500/50 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-all" 
+                        <button className={`flex items-center gap-2 text-xs font-bold text-white bg-slate-800 px-3 py-1.5 rounded-lg border border-white/10 hover:border-blue-500/50 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-all ${isRegeneratingCode? 'opacity-50':'opacity-100'}`}
                           onClick={() => setshowLanguageDropDown(p => !p)}
+                          disabled={isRegeneratingCode}
                         >
                           {codeLanguage} 
                           <ChevronDown size={12} className={`transition-transform ${showLanguageDropDown ? 'rotate-180' : ''}`} />


### PR DESCRIPTION
## Description

Disabled the drop down while code is being regenerated. 

## Related Issue

Closes #24 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactor (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔧 Chore (build process, dependencies, etc.)

## Changes Made
- Disabled dropdown when regenerating code
- Added opacity based on disable condition

## How Has This Been Tested?

- [x] Tested locally (frontend: `npm run dev`, backend: `uvicorn server:app --reload`)
- [x] Verified existing tests still pass (`pytest test_server.py -v` / `npm run build`)
- [ ] Added new tests for the changes

**Test environment:**
- OS: Windows 11
- Node.js version: v22.16.0
- Python version: 3.12.4

## Screenshots (if applicable)

<img width="552" height="628" alt="image" src="https://github.com/user-attachments/assets/ba0285a1-f423-4826-863a-805646c8618c" />

## Checklist

- [x] My code follows the existing code style of the project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary (especially in complex logic)
- [x] I have updated the documentation if needed
- [x]  My changes do not introduce any new warnings or errors
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] All new and existing tests pass locally

## GSSOC

- [x] This contribution is part of **GirlScript Summer of Code (GSSOC)**

##Note: This PR depends on #34 and should only be merged after it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dropdown interaction: the code-language selector now closes automatically after generating graphs or changing languages.

* **Bug Fixes**
  * Language selector is disabled while code is regenerating to prevent accidental interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/priyanshu5ingh/VISUALAIZE/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->