### PR TITLE
fix: Handle markdown-wrapped JSON responses from Gemini API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import os
 import json
 import sys
+import re
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,6 +9,26 @@ import google.generativeai as genai
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# --- UTILITY FUNCTION: Safe JSON Parser ---
+def parse_json_response(response_text: str):
+    """
+    Safely parse JSON from LLM response, handling markdown code blocks.
+    
+    Handles cases like:
+    - ```json\n{...}\n```
+    - ```\n{...}\n```
+    - {raw JSON}
+    """
+    # Remove markdown code block wrapper if present
+    # Pattern: optional backticks + optional language tag + content + optional backticks
+    json_match = re.search(r'```(?:json)?\s*([\s\S]*?)\s*```', response_text)
+    if json_match:
+        response_text = json_match.group(1).strip()
+    else:
+        response_text = response_text.strip()
+    
+    return json.loads(response_text)
 
 # --- 1. SETUP API KEY ---
 GENAI_KEY = os.getenv("GEMINI_API_KEY")
@@ -120,7 +141,7 @@ async def generate_graph(request: GraphRequest):
     """
     try:
         response_text = get_smart_response(f"{system_prompt}\n\nUSER PROMPT: {request.prompt}", use_json=True)
-        return json.loads(response_text)
+        return parse_json_response(response_text)
     except Exception as e:
         print(f"Error: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,17 +15,23 @@ def parse_json_response(response_text: str):
     """
     Safely parse JSON from LLM response, handling markdown code blocks.
     
+    Only unwraps if the ENTIRE response is a fenced block to avoid breaking
+    valid JSON that contains backticks in field values (e.g., code_snippet).
+    
     Handles cases like:
     - ```json\n{...}\n```
     - ```\n{...}\n```
-    - {raw JSON}
+    - {raw JSON with "field": "```code```"}
     """
-    # Remove markdown code block wrapper if present
-    # Pattern: optional backticks + optional language tag + content + optional backticks
-    json_match = re.search(r'```(?:json)?\s*([\s\S]*?)\s*```', response_text)
-    if json_match:
-        response_text = json_match.group(1).strip()
-    else:
+    response_text = response_text.strip()
+    
+    # Only unwrap if the entire response is wrapped in backticks
+    # This prevents breaking JSON with backticks in field values
+    if response_text.startswith('```') and response_text.endswith('```'):
+        # Remove opening fence (``` or ```json)
+        response_text = re.sub(r'^```(?:json)?\s*', '', response_text)
+        # Remove closing fence (```)
+        response_text = re.sub(r'\s*```$', '', response_text)
         response_text = response_text.strip()
     
     return json.loads(response_text)

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,8 +28,8 @@ def parse_json_response(response_text: str):
     # Only unwrap if the entire response is wrapped in backticks
     # This prevents breaking JSON with backticks in field values
     if response_text.startswith('```') and response_text.endswith('```'):
-        # Remove opening fence (``` or ```json)
-        response_text = re.sub(r'^```(?:json)?\s*', '', response_text)
+        # Remove opening fence and any optional Markdown info string (json, JSON, js, etc.)
+        response_text = re.sub(r'^```[^\n]*\n?', '', response_text)
         # Remove closing fence (```)
         response_text = re.sub(r'\s*```$', '', response_text)
         response_text = response_text.strip()


### PR DESCRIPTION
Issue : #8 

Fixes a critical issue where Gemini API responses wrapped in markdown code blocks (e.g., ```json {...} ```) would cause JSONDecodeError and crash the /generate endpoint with a 500 error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of response parsing in the generation endpoint: the service now more reliably interprets structured model outputs (including trimmed content and JSON wrapped in fenced code blocks), reducing failures when consuming generated JSON and improving overall stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/priyanshu5ingh/VISUALAIZE/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->