### PR TITLE
Feat: Implemented Code Caching

### DIFF
--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -1,23 +1,48 @@
 // frontend/src/components/GraphEditor.tsx
 'use client';
 
-import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import ReactFlow, { 
-  Background, BackgroundVariant, Controls, MiniMap, applyEdgeChanges, applyNodeChanges, 
-  Node, Edge, OnNodesChange, OnEdgesChange, MarkerType, useReactFlow, ReactFlowProvider
+import { toPng } from 'html-to-image';
+import {
+  Activity,
+  ArrowLeft,
+  BookOpen,
+  Box,
+  Check,
+  ChevronDown,
+  Code, Copy,
+  Download,
+  GitBranch,
+  Globe,
+  Layers,
+  MessageSquare,
+  Mic,
+  Network,
+  PanelRightClose, PanelRightOpen,
+  Paperclip,
+  PlayCircle,
+  RefreshCw,
+  Send,
+  Share2, Terminal,
+  Zap
+} from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactFlow, {
+  applyEdgeChanges, applyNodeChanges,
+  Background, BackgroundVariant, Controls,
+  Edge,
+  MarkerType,
+  MiniMap,
+  Node,
+  OnEdgesChange,
+  OnNodesChange,
+  ReactFlowProvider,
+  useReactFlow
 } from 'reactflow';
 import 'reactflow/dist/style.css';
-import { toPng } from 'html-to-image';
-import { getLayoutedElements } from '../utils/layout'; 
-import { 
-  ArrowLeft, Box, GitBranch, Network, Share2, Terminal, 
-  Activity, BookOpen, PlayCircle, Layers, Code, Copy, Check, Zap, 
-  Globe, Mic, Download, ChevronDown, MessageSquare, Send, Paperclip, 
-  PanelRightClose, PanelRightOpen 
-} from 'lucide-react';
 import CustomNode from '../components/CustomNode';
-import LoadingCore from './LoadingCore'; 
+import { getLayoutedElements } from '../utils/layout';
 import HolographicScene from './HolographicScene';
+import LoadingCore from './LoadingCore';
 
 interface EditorProps { onBack: () => void; }
 
@@ -32,6 +57,11 @@ interface GraphData {
   code_explanation?: string;
   nodes: { id: string; label: string }[];
   edges: { source: string; target: string; label: string }[];
+}
+
+interface codeObject {
+  code_snippet: string;
+  code_explanation: string;
 }
 
 // --- SpeechRecognition type shim (not in lib.dom.d.ts) ---
@@ -179,6 +209,7 @@ function EditorContent({ onBack }: EditorProps) {
   
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
+  const codeCache = useRef(new Map<string, codeObject>());
   const reactFlowWrapper = useRef(null);
   const fileInputRef = useRef<HTMLInputElement>(null); 
   const { getNodes } = useReactFlow(); 
@@ -217,6 +248,8 @@ function EditorContent({ onBack }: EditorProps) {
       console.log("✅ [SUCCESS] Data received:", data);
       
       setGraphData(data);
+      codeCache.current.clear();
+      codeCache.current.set(codeLanguage, {code_snippet: data.code_snippet ?? '', code_explanation: data.code_explanation ?? ''});
       
       const rawNodes: Node[] = data.nodes.map((n: { id: string; label: string }) => ({
         id: n.id, type: 'default', data: { label: n.label }, position: { x: 0, y: 0 },
@@ -250,12 +283,19 @@ function EditorContent({ onBack }: EditorProps) {
       });
       const data = await res.json();
       setGraphData((prev: GraphData | null) => prev ? ({ ...prev, code_snippet: data.code_snippet, code_explanation: data.code_explanation }) : prev);
+      if (data) codeCache.current.set(newLang, {code_snippet: data.code_snippet ?? '', code_explanation: data.code_explanation ?? ''})
     } catch (err) { alert("Failed to rewrite code."); } finally { setIsRegeneratingCode(false); }
   } 
 
   const handleLanguageChange = async (newLang: string) => {
     setshowLanguageDropDown(false);
     if (newLang === codeLanguage || !graphData) return;
+    if (codeCache.current.has(newLang)){
+      setCodeLanguage(newLang);
+      const cachedCodeData = codeCache.current.get(newLang);
+      setGraphData((prev: GraphData | null) => prev && cachedCodeData ? ({ ...prev, code_snippet: cachedCodeData.code_snippet, code_explanation: cachedCodeData.code_explanation }) : prev);
+      return; 
+    }
     regenerateCode(newLang);
   };
 
@@ -441,7 +481,8 @@ function EditorContent({ onBack }: EditorProps) {
                 {activeTab === 'CODE' && (
                   <div className="h-full flex flex-col">
                     <div className="flex justify-between items-center mb-4">
-                      <div className="relative">
+                      <div className="relative flex gap-2">
+                        <div className="">
                         <button className={`flex items-center gap-2 text-xs font-bold text-white bg-slate-800 px-3 py-1.5 rounded-lg border border-white/10 hover:border-blue-500/50 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-all ${isRegeneratingCode? 'opacity-50':'opacity-100'}`}
                           onClick={() => setshowLanguageDropDown(p => !p)}
                           disabled={isRegeneratingCode}
@@ -469,6 +510,10 @@ function EditorContent({ onBack }: EditorProps) {
                           </div>
                           </>
                         )}
+                      </div>
+                            <button className={`flex items-center gap-2 text-xs font-bold text-white bg-slate-800 px-3 py-1.5 rounded-lg border border-white/10 hover:border-blue-500/50 transition-colors ${isRegeneratingCode? 'opacity-50': 'opacity-100'}`}  disabled={isRegeneratingCode} onClick={()=>regenerateCode(codeLanguage)}>
+                              <RefreshCw size={14}/>
+                            </button>
                       </div>
                       <button onClick={handleCopyCode} className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-xs font-bold transition-colors">
                         {copied ? <Check size={14} /> : <Copy size={14} />} {copied ? 'COPIED' : 'COPY'}

--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -511,7 +511,13 @@ function EditorContent({ onBack }: EditorProps) {
                           </>
                         )}
                       </div>
-                            <button className={`flex items-center gap-2 text-xs font-bold text-white bg-slate-800 px-3 py-1.5 rounded-lg border border-white/10 hover:border-blue-500/50 transition-colors ${isRegeneratingCode? 'opacity-50': 'opacity-100'}`}  disabled={isRegeneratingCode} onClick={()=>regenerateCode(codeLanguage)}>
+                            <button
+                              className={`flex items-center gap-2 text-xs font-bold text-white bg-slate-800 px-3 py-1.5 rounded-lg border border-white/10 hover:border-blue-500/50 transition-colors ${isRegeneratingCode? 'opacity-50': 'opacity-100'}`}
+                              disabled={isRegeneratingCode}
+                              onClick={() => regenerateCode(codeLanguage)}
+                              aria-label="Regenerate code"
+                              title="Regenerate code"
+                            >
                               <RefreshCw size={14}/>
                             </button>
                       </div>


### PR DESCRIPTION
## Description
Created a cache for the code and the explanation to reduce api calls when changing languages. 

## Related Issue
Closes #25 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactor (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔧 Chore (build process, dependencies, etc.)

## Changes Made

- Added a ref object that stores the cached code 
- Added a seperate button for code regeneration 
- Created a code object that holds both the code_snippet and code_explanation. 

## How Has This Been Tested?

- [x] Tested locally (frontend: `npm run dev`, backend: `uvicorn server:app --reload`)
- [x] Verified existing tests still pass (`pytest test_server.py -v` / `npm run build`)
- [ ] Added new tests for the changes

**Test environment:**
- OS: Windows 11 
- Node.js version: 22.16.0
- Python version: 3.12.4

## Screenshots (if applicable)

https://github.com/user-attachments/assets/fdab07de-4173-4c83-9f0f-e8d79e0eafe5

https://github.com/user-attachments/assets/87ba288c-9759-4342-8400-ca7dbabab087


## Checklist

- [x] My code follows the existing code style of the project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary (especially in complex logic)
- [x] I have updated the documentation if needed
- [x] My changes do not introduce any new warnings or errors
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] All new and existing tests pass locally

## GSSOC

- [x] This contribution is part of **GirlScript Summer of Code (GSSOC)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-language code caching for faster switching between previously used languages.
  * CODE tab UI updated: controls reflow for better layout, added a regenerate button to refresh snippets, and shows disabled/opacity styling while regeneration is in progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/priyanshu5ingh/VISUALAIZE/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->