### PR TITLE
feat: add custom icons to ReactFlow architecture nodes #42

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "dagre": "^0.8.5",
         "framer-motion": "^12.38.0",
         "html-to-image": "^1.11.13",
-        "lucide-react": "^1.14.0",
+        "lucide-react": "^1.16.0",
         "maath": "^0.10.8",
         "mini-svg-data-uri": "^1.4.4",
         "next": "16.2.6",
@@ -5739,9 +5739,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
-      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "dagre": "^0.8.5",
     "framer-motion": "^12.38.0",
     "html-to-image": "^1.11.13",
-    "lucide-react": "^1.14.0",
+    "lucide-react": "^1.16.0",
     "maath": "^0.10.8",
     "mini-svg-data-uri": "^1.4.4",
     "next": "16.2.6",

--- a/frontend/src/components/CustomNode.tsx
+++ b/frontend/src/components/CustomNode.tsx
@@ -1,27 +1,34 @@
 import React, { memo } from 'react';
 import { Handle, Position } from 'reactflow';
-import { Cpu, Database, Activity, ArrowRightCircle } from 'lucide-react';
+import { Database, ArrowRightCircle, Server, Globe, Cloud, Shield, Box,  Activity } from 'lucide-react';
 
 interface CustomNodeProps {
-  data: { label: string };
+  data: { label: string; type?: string };
   selected?: boolean;
 }
 
 const CustomNode = ({ data, selected }: CustomNodeProps) => {
   // 1. Auto-detect the icon based on the text label
-  let Icon = Activity;
+  const label = data.label.toLowerCase();
+  const t = (data.type ?? '').toLowerCase();
+
+  let Icon = Box;
   let glowColor = "shadow-blue-500/50";
   let borderColor = "border-blue-400/30";
+  let tag = "Node";
 
-  const label = data.label.toLowerCase();
-  if (label.includes('start')) {
-    Icon = ArrowRightCircle;
-    glowColor = "shadow-emerald-500/50";
-    borderColor = "border-emerald-400/50";
-  } else if (label.includes('end') || label.includes('accept') || label.includes('final')) {
-    Icon = Database;
-    glowColor = "shadow-purple-500/50";
-    borderColor = "border-purple-400/50";
+  if (t === 'database' || label.includes('database') || label.includes('db')) {
+    Icon = Database; glowColor = "shadow-purple-500/50"; borderColor = "border-purple-400/50"; tag = "Database";
+  } else if (t === 'server' || label.includes('server') || label.includes('api') || label.includes('backend')) {
+    Icon = Server; glowColor = "shadow-orange-500/50"; borderColor = "border-orange-400/50"; tag = "Server";
+  } else if (t === 'client' || t === 'frontend' || label.includes('client') || label.includes('frontend')) {
+    Icon = Globe; glowColor = "shadow-cyan-500/50"; borderColor = "border-cyan-400/50"; tag = "Client";
+  } else if (t === 'cloud' || label.includes('cloud') || label.includes('aws')) {
+    Icon = Cloud; glowColor = "shadow-sky-500/50"; borderColor = "border-sky-400/50"; tag = "Cloud";
+  } else if (t === 'auth' || label.includes('auth') || label.includes('login')) {
+    Icon = Shield; glowColor = "shadow-green-500/50"; borderColor = "border-green-400/50"; tag = "Auth";
+  } else if (label.includes('start')) {
+    Icon = ArrowRightCircle; glowColor = "shadow-emerald-500/50"; borderColor = "border-emerald-400/50"; tag = "Start";
   }
 
   return (
@@ -51,7 +58,7 @@ const CustomNode = ({ data, selected }: CustomNodeProps) => {
         </div>
         
         <div className="flex flex-col">
-          <span className="text-[10px] uppercase tracking-widest text-slate-500 font-bold">State</span>
+          <span className="text-[10px] uppercase tracking-widest text-slate-500 font-bold">{tag}</span>
           <span className={`text-sm font-semibold tracking-wide ${selected ? 'text-white' : 'text-slate-200'}`}>
             {data.label}
           </span>

--- a/frontend/src/components/CustomNode.tsx
+++ b/frontend/src/components/CustomNode.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import { Handle, Position } from 'reactflow';
-import { Database, ArrowRightCircle, Server, Globe, Cloud, Shield, Box,  Activity } from 'lucide-react';
+import { Database, ArrowRightCircle, Server, Globe, Cloud, Shield, Box } from 'lucide-react';
 
 interface CustomNodeProps {
   data: { label: string; type?: string };


### PR DESCRIPTION
## Description

Added custom icons and color-coded borders to ReactFlow architecture nodes based on their type. Previously all nodes looked like plain rectangular boxes. Now each node type renders a relevant icon with a unique glow and border color.

Closes #42 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Code refactor (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔧 Chore (build process, dependencies, etc.)

## Changes Made

- Implemented icon mapping using `lucide-react` based on `data.type` and label keywords
- Added support for:
  - Client/Frontend nodes (cyan)
  - Server/API nodes (orange)
  - Database nodes (purple)
  - Auth nodes (green)
  - Cloud nodes (sky)
- Installed `lucide-react` dependency

## How Has This Been Tested?

- [x] Tested locally (frontend: `npm run dev)
- [ ] Verified existing tests still pass (`pytest test_server.py -v` / `npm run build`)
- [ ] Added new tests for the changes

**Test environment:**
- OS: Windows
- Node.js version: v22.17.0
- Python version: 

## Screenshots (if applicable)
<img width="1368" height="823" alt="Screenshot 2026-05-20 014139" src="https://github.com/user-attachments/assets/c9a476fa-ff3c-48ee-9d1a-7fc7a0c90271" />

<img width="1918" height="1021" alt="Screenshot 2026-05-20 014010" src="https://github.com/user-attachments/assets/d84ce3d4-e07c-4217-8729-b667ff1fc524" />

## Checklist

- [x] My code follows the existing code style of the project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary (especially in complex logic)
- [ ] I have updated the documentation if needed
- [x] My changes do not introduce any new warnings or errors
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] All new and existing tests pass locally

## GSSOC

- [x] This contribution is part of **GirlScript Summer of Code (GSSOC)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nodes now show dynamic category labels (Database, Server, Client, Cloud, Auth, Start, etc.) and render a computed uppercase tag in the header.
  * Nodes use type-driven icons plus corresponding glow and border colors for clearer visual distinction.

* **Refactor**
  * Component updated to centralize type-based categorization and styling logic for nodes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/priyanshu5ingh/VISUALAIZE/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->