### PR TITLE
Hide ReactFlow controls before diagram generation

### DIFF
--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -401,13 +401,37 @@ function EditorContent({ onBack }: EditorProps) {
         {nodes.length === 0 && !isGenerating && <SystemLogs />}
 
         {/* MAIN GRAPH AREA */}
-        <div className="flex-1 w-full h-full">
-            <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} fitView minZoom={0.1}>
-                <Background color="#94a3b8" gap={40} size={1} variant={BackgroundVariant.Dots} className="opacity-[0.1]" />
-                <Controls /> 
-                <MiniMap className="!bg-slate-900/80 !backdrop-blur-md !border-slate-800 rounded-lg" nodeColor="#3b82f6" maskColor="rgba(15, 23, 42, 0.6)" />
-            </ReactFlow>
-        </div>
+<div className="flex-1 w-full h-full">
+    <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        fitView
+        minZoom={0.1}
+    >
+        <Background
+            color="#94a3b8"
+            gap={40}
+            size={1}
+            variant={BackgroundVariant.Dots}
+            className="opacity-[0.1]"
+        />
+
+        {/* Show controls only after graph generation */}
+        {nodes.length > 0 && <Controls />}
+
+        {/* Show minimap only after graph generation */}
+        {nodes.length > 0 && (
+            <MiniMap
+                className="!bg-slate-900/80 !backdrop-blur-md !border-slate-800 rounded-lg"
+                nodeColor="#3b82f6"
+                maskColor="rgba(15, 23, 42, 0.6)"
+            />
+        )}
+    </ReactFlow>
+</div>
 
         {/* INPUT BAR */}
         <div className="absolute bottom-10 left-1/2 -translate-x-1/2 w-[600px] z-50">


### PR DESCRIPTION
## Description

This PR improves the UI/UX of the graph editor by conditionally rendering the ReactFlow controls and minimap only after a diagram has been generated.

### Changes Made
- Hid zoom/navigation controls before graph generation
- Hid minimap before graph generation
- Added conditional rendering using `nodes.length > 0`

### Before
(Drag old screenshot here)
<img width="1258" height="599" alt="Screenshot 2026-05-20 182013" src="https://github.com/user-attachments/assets/49475a3c-ba2e-4e0d-ada7-4fd8aa7b5aa3" />

### After
(Drag updated screenshot here)
<img width="1270" height="598" alt="Screenshot 2026-05-20 185349" src="https://github.com/user-attachments/assets/5a9c1bec-5546-4b42-bb4f-a35f7a7dddf5" />

### Result
- Cleaner initial landing UI
- Better first-time user experience
- Reduced unnecessary controls on empty canvas

Fixes #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized graph editor layout and structure; interface controls now display only when content is present for a cleaner user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/priyanshu5ingh/VISUALAIZE/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->