### PR TITLE
fix: add prompt length validation on /generate endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -104,6 +104,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+MAX_PROMPT_LENGTH = 2000
+
 class GraphRequest(BaseModel):
     prompt: str
 
@@ -194,6 +196,10 @@ def health_check():
 
 @app.post("/generate")
 async def generate_graph(request: GraphRequest):
+    if not request.prompt.strip():
+        raise HTTPException(status_code=400, detail="Prompt cannot be empty.")
+    if len(request.prompt) > MAX_PROMPT_LENGTH:
+        raise HTTPException(status_code=400, detail=f"Prompt is too long. Please keep it under {MAX_PROMPT_LENGTH} characters.")
     if not GENAI_KEY or GENAI_KEY == "missing" or not GENAI_KEY.strip():
         raise HTTPException(
             status_code=401,


### PR DESCRIPTION
Fixes #109

## What's Changed
- Added `MAX_PROMPT_LENGTH = 2000` constant in `backend/main.py`
- Added empty prompt check — returns 400 with clear error message
- Added length check — returns 400 if prompt exceeds 2000 characters

## How to Test
1. Send a POST request to `/generate` with an empty prompt → should get 400 "Prompt cannot be empty."
2. Send a POST request to `/generate` with 2000+ character prompt → should get 400 "Prompt is too long. Please keep it under 2000 characters."

## Files Changed
- `backend/main.py`