### PR TITLE
fix: warn user before leaving with unsaved diagram

### DIFF
--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -268,6 +268,17 @@ function EditorContent({ onBack }: EditorProps) {
 
   const rafRef = useRef<number | null>(null);
   const socketRef = useRef<WebSocket | null>(null);
+  // Warn user before leaving with unsaved diagram
+useEffect(() => {
+  const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+    if (nodes.length > 0) {
+      e.preventDefault();
+      e.returnValue = '';
+    }
+  };
+  window.addEventListener('beforeunload', handleBeforeUnload);
+  return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+}, [nodes]);
 
   const onMove = useCallback((_: any, vp: any) => {
   if (rafRef.current) cancelAnimationFrame(rafRef.current);


### PR DESCRIPTION
Fixes #110

## What's Changed
- Added `beforeunload` event listener in `GraphEditor.tsx`
- Browser now shows a confirmation dialog if user tries to refresh or navigate away with a diagram loaded
- Listener is cleaned up on component unmount to avoid memory leaks

## Files Changed
- `frontend/src/components/GraphEditor.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt in the graph editor. When you attempt to close your browser tab or navigate away while working with graph nodes, you'll receive a confirmation dialog to prevent accidental data loss.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/priyanshu5ingh/VISUALAIZE/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->