### PR TITLE
feat: add system-wide dark and light mode toggle

### DIFF
--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const STORAGE_KEY = 'visualaize-theme';
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') return;
+
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+  document.documentElement.dataset.theme = theme;
+}
+
+function getPreferredTheme(): Theme {
+  if (typeof window === 'undefined') return 'dark';
+
+  const savedTheme = window.localStorage.getItem(STORAGE_KEY);
+  if (savedTheme === 'light' || savedTheme === 'dark') {
+    return savedTheme;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => getPreferredTheme());
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = useCallback((nextTheme: Theme) => {
+    setThemeState(nextTheme);
+    window.localStorage.setItem(STORAGE_KEY, nextTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  }, [theme, setTheme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+      setTheme,
+    }),
+    [theme, toggleTheme, setTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+
+  return context;
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from './ThemeProvider';
+
+export default function ThemeToggle({ className = '' }: { className?: string }) {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      className={`focus-ring inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/85 px-4 py-2 text-xs font-semibold tracking-[0.2em] text-slate-700 shadow-lg shadow-slate-200/40 backdrop-blur-md transition-all hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-200 dark:shadow-black/20 dark:hover:bg-slate-800/80 ${className}`}
+    >
+      {isDark ? <Sun size={14} /> : <Moon size={14} />}
+      <span>{isDark ? 'LIGHT' : 'DARK'}</span>
+    </button>
+  );
+}

--- a/frontend/src/types/react-three-fiber.d.ts
+++ b/frontend/src/types/react-three-fiber.d.ts
@@ -1,0 +1,9 @@
+import type { ThreeElements } from '@react-three/fiber';
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ThreeElements {}
+  }
+}
+
+export {};


### PR DESCRIPTION
﻿## Summary
- add a persistent system-wide dark/light theme provider with local storage + system-theme fallback
- add a sun/moon toggle to the landing page, about page, and graph editor toolbar
- update the main landing, about, and editor shell surfaces to respond to the selected theme
- include the small React Three Fiber typing bridge needed by this workspace while verifying the frontend

## Testing
- `npm run lint` (passes with warnings only)
- `npx next build --webpack` currently reaches prerendering and then fails on the existing `/` prerender issue in this repo

Fixes #46

If this looks good, please add `gssoc:approved` so the contribution counts correctly for GSSoC'26.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a theme toggle button to switch between light and dark color modes
  * User theme preference is automatically saved and restored across sessions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/priyanshu5ingh/VISUALAIZE/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->