### PR TITLE
docs: add architecture diagram showing Redis and Gemini integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,23 @@ VisualAIze/
 └── backend/                           # Python Backend
     ├── test_key.py                   # Gemini API Key Validation
     └── venv/                         # Virtual Environment
-
-  ---
-
-  ## 🖼️ Diagrams
-
-  Visual diagrams for the architecture and data flow are available in the `docs/` folder.
-
-  ![Architecture Diagram](docs/architecture.svg)
-
-  ![Data Flow](docs/data-flow.svg)
 ```
+
+---
+
+## 🖼️ Diagrams
+
+Visual diagrams for the architecture and data flow are available in the `docs/` folder.
+
+![Architecture Diagram](docs/architecture.svg)
+
+![Data Flow](docs/data-flow.svg)
+
+### Request flow: Frontend, Backend, Redis & Gemini
+
+![Architecture overview with Redis cache](docs/architecture-overview.svg)
+
+This diagram shows how a request travels from the **Next.js frontend** to the **FastAPI backend**, which checks **Redis** for a cached diagram before calling the **Gemini API** to generate new graph data — caching the result for future requests.
 
 ---
 

--- a/docs/architecture-overview.svg
+++ b/docs/architecture-overview.svg
@@ -1,0 +1,44 @@
+<svg width="680" height="460" viewBox="0 0 680 460" xmlns="http://www.w3.org/2000/svg" role="img">
+  <title>VisualAIze system architecture</title>
+  <desc>Diagram showing the Next.js frontend sending requests to the FastAPI backend, which checks a Redis cache and calls the Gemini API to generate diagram data, then returns the result to the frontend.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#5F5E5A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .title { font-size: 14px; font-weight: 500; }
+    .sub { font-size: 12px; }
+    .box { stroke-width: 0.5; }
+  </style>
+  <rect class="box" x="250" y="30" width="180" height="56" rx="8" fill="#E6F1FB" stroke="#185FA5"/>
+  <text class="title" x="340" y="50" text-anchor="middle" fill="#042C53">Frontend</text>
+  <text class="sub" x="340" y="68" text-anchor="middle" fill="#185FA5">Next.js, ReactFlow UI</text>
+  <line x1="320" y1="86" x2="320" y2="140" stroke="#5F5E5A" stroke-width="0.5" marker-end="url(#arrow)"/>
+  <line x1="360" y1="140" x2="360" y2="86" stroke="#5F5E5A" stroke-width="0.5" marker-end="url(#arrow)"/>
+  <text class="sub" x="240" y="118" text-anchor="end" fill="#5F5E5A">prompt</text>
+  <text class="sub" x="440" y="118" text-anchor="start" fill="#5F5E5A">diagram JSON</text>
+  <rect class="box" x="250" y="140" width="180" height="56" rx="8" fill="#EEEDFE" stroke="#534AB7"/>
+  <text class="title" x="340" y="160" text-anchor="middle" fill="#26215C">Backend</text>
+  <text class="sub" x="340" y="178" text-anchor="middle" fill="#534AB7">FastAPI, /api/generate</text>
+  <line x1="290" y1="196" x2="160" y2="280" stroke="#5F5E5A" stroke-width="0.5" marker-end="url(#arrow)"/>
+  <line x1="160" y1="280" x2="290" y2="196" stroke="#5F5E5A" stroke-width="0.5" marker-end="url(#arrow)"/>
+  <text class="sub" x="180" y="230" text-anchor="end" fill="#5F5E5A">cache check</text>
+  <text class="sub" x="180" y="248" text-anchor="end" fill="#5F5E5A">cached result</text>
+  <line x1="430" y1="196" x2="520" y2="280" stroke="#5F5E5A" stroke-width="0.5" marker-end="url(#arrow)"/>
+  <line x1="520" y1="280" x2="430" y2="196" stroke="#5F5E5A" stroke-width="0.5" marker-end="url(#arrow)"/>
+  <text class="sub" x="500" y="230" text-anchor="start" fill="#5F5E5A">if not cached</text>
+  <text class="sub" x="500" y="248" text-anchor="start" fill="#5F5E5A">graph JSON</text>
+  <rect class="box" x="60" y="280" width="170" height="56" rx="8" fill="#FAECE7" stroke="#993C1D"/>
+  <text class="title" x="145" y="300" text-anchor="middle" fill="#4A1B0C">Redis cache</text>
+  <text class="sub" x="145" y="318" text-anchor="middle" fill="#993C1D">Stores recent results</text>
+  <rect class="box" x="450" y="280" width="170" height="56" rx="8" fill="#E1F5EE" stroke="#0F6E56"/>
+  <text class="title" x="535" y="300" text-anchor="middle" fill="#04342C">Gemini API</text>
+  <text class="sub" x="535" y="318" text-anchor="middle" fill="#0F6E56">Generates nodes/edges</text>
+  <text class="sub" x="340" y="390" text-anchor="middle" fill="#444441">
+    <tspan x="340" dy="0">A user prompt flows from the frontend to the backend, which</tspan>
+    <tspan x="340" dy="18">first checks Redis for a cached diagram, then calls Gemini</tspan>
+    <tspan x="340" dy="18">if needed, caching and returning the resulting graph JSON.</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
## Description
Added a new architecture diagram to the README that explicitly shows the interaction between the Next.js frontend, FastAPI backend, Redis cache, and Gemini API, along with a short caption explaining the request flow. The existing diagrams (architecture.svg, data-flow.svg) didn't show Redis, so this new diagram covers the full stack as requested in the issue.

## Related Issue
Closes #147

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactor (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔧 Chore (build process, dependencies, etc.)

## Changes Made
- Added `docs/architecture-overview.svg` showing Frontend → Backend → Redis cache / Gemini API interactions
- Added a new "Request flow: Frontend, Backend, Redis & Gemini" section to README.md with the diagram embedded
- Added a short caption explaining the cache-check and Gemini fallback flow
- Fixed an unclosed code block in the Component Architecture section of README.md so the new section renders correctly as Markdown

## How Has This Been Tested?
- [x] Tested locally (frontend: `npm run dev`, backend: `uvicorn server:app --reload`)
- [ ] Verified existing tests still pass (`pytest test_server.py -v` / `npm run build`)
- [ ] Added new tests for the changes

**Test environment:**
- OS: Windows 11
- Node.js version: N/A (docs-only change)
- Python version: N/A (docs-only change)

## Screenshots (if applicable)
N/A — added an SVG diagram embedded in README.md; rendered preview shows the new "Request flow" section with the architecture diagram and caption.

## Checklist
- [x] My code follows the existing code style of the project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary (especially in complex logic)
- [x] I have updated the documentation if needed
- [x] My changes do not introduce any new warnings or errors
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] All new and existing tests pass locally

## GSSOC
- [x] This contribution is part of **GirlScript Summer of Code (GSSOC)**