### PR TITLE
(#79)Lock mode does not disable ReactFlow Controls After graph locking

### DIFF
--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -285,6 +285,7 @@ function EditorContent({ onBack }: EditorProps) {
 
   const [cursors, setCursors] = useState<Record<string, { x: number; y: number }>>({});
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isLocked, setIsLocked] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [savedHistory, setSavedHistory] = useState<SavedDiagram[]>([]);
 
@@ -826,15 +827,17 @@ function EditorContent({ onBack }: EditorProps) {
         </div>
 
         {/* Focus mode toggle */}
-        <button
-          onClick={() => setIsFullscreen(f => !f)}
-          className="focus-ring absolute top-4 right-4 z-50 pointer-events-auto flex items-center gap-2 px-3 py-1.5 rounded-full bg-slate-900/60 backdrop-blur-md border border-white/10 text-xs font-mono text-slate-300 hover:bg-blue-600 hover:text-white hover:border-blue-500/50 transition-all shadow-lg"
-          title={isFullscreen ? 'Exit Focus Mode (Esc)' : 'Focus Mode'}
-          aria-label={isFullscreen ? 'Exit Focus Mode' : 'Enter Focus Mode'}
-        >
-          {isFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
-          {isFullscreen ? 'EXIT FOCUS' : 'FOCUS'}
-        </button>
+        {!isLocked && (
+          <button
+            onClick={() => setIsFullscreen(f => !f)}
+            className="focus-ring absolute top-4 right-4 z-50 pointer-events-auto flex items-center gap-2 px-3 py-1.5 rounded-full bg-slate-900/60 backdrop-blur-md border border-white/10 text-xs font-mono text-slate-300 hover:bg-blue-600 hover:text-white hover:border-blue-500/50 transition-all shadow-lg"
+            title={isFullscreen ? 'Exit Focus Mode (Esc)' : 'Focus Mode'}
+            aria-label={isFullscreen ? 'Exit Focus Mode' : 'Enter Focus Mode'}
+          >
+            {isFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+            {isFullscreen ? 'EXIT FOCUS' : 'FOCUS'}
+          </button>
+        )}
 
         {/* Empty state: shown when no graph has been generated yet */}
         {nodes.length === 0 && !isGenerating && <EmptyState />}
@@ -855,6 +858,14 @@ function EditorContent({ onBack }: EditorProps) {
               onEdgesChange={onEdgesChange}
               onMove={onMove}
               minZoom={0.1}
+              nodesDraggable={!isLocked}
+              nodesConnectable={!isLocked}
+              elementsSelectable={!isLocked}
+              panOnDrag={!isLocked}
+              panOnScroll={!isLocked}
+              zoomOnScroll={!isLocked}
+              zoomOnPinch={!isLocked}
+              zoomOnDoubleClick={!isLocked}
             >
                 <Background
                     color="#94a3b8"
@@ -866,33 +877,39 @@ function EditorContent({ onBack }: EditorProps) {
 
                 {nodes.length > 0 && (
                   <Controls showZoom={false} showFitView={false} showInteractive={false}>
+                    {!isLocked && (
+                      <ControlButton
+                        onClick={() => zoomIn({ duration: 300 })}
+                        title="Zoom In"
+                        aria-label="Zoom in"
+                      >
+                        <ZoomIn size={14} />
+                      </ControlButton>
+                    )}
+                    {!isLocked && (
+                      <ControlButton
+                        onClick={() => zoomOut({ duration: 300 })}
+                        title="Zoom Out"
+                        aria-label="Zoom out"
+                      >
+                        <ZoomOut size={14} />
+                      </ControlButton>
+                    )}
+                    {!isLocked && (
+                      <ControlButton
+                        onClick={() => fitView({ padding: 0.15, duration: 500 })}
+                        title="Fit View"
+                        aria-label="Fit view"
+                      >
+                        <Maximize size={14} />
+                      </ControlButton>
+                    )}
                     <ControlButton
-                      onClick={() => zoomIn({ duration: 300 })}
-                      title="Zoom In"
-                      aria-label="Zoom in"
+                      onClick={() => setIsLocked(prev => !prev)}
+                      title={isLocked ? "Unlock Graph" : "Lock Graph"}
+                      aria-label={isLocked ? "Unlock Graph" : "Lock Graph"}
                     >
-                      <ZoomIn size={14} />
-                    </ControlButton>
-                    <ControlButton
-                      onClick={() => zoomOut({ duration: 300 })}
-                      title="Zoom Out"
-                      aria-label="Zoom out"
-                    >
-                      <ZoomOut size={14} />
-                    </ControlButton>
-                    <ControlButton
-                      onClick={() => fitView({ padding: 0.15, duration: 500 })}
-                      title="Fit View"
-                      aria-label="Fit view"
-                    >
-                      <Maximize size={14} />
-                    </ControlButton>
-                    <ControlButton
-                      onClick={() => setNodes(nds => nds.map(n => ({ ...n, draggable: !(n.draggable ?? true) })))}
-                      title="Toggle Interactive (lock/unlock nodes)"
-                      aria-label="Toggle interactive"
-                    >
-                      <Lock size={14} />
+                      {isLocked ? <Lock size={14} /> : <Unlock size={14} />}
                     </ControlButton>
                   </Controls>
                 )}


### PR DESCRIPTION
## Description

This PR fixes the lock mode behavior in the ReactFlow graph editor.

Previously, enabling lock mode only partially restricted interactions, allowing users to continue using zoom and fullscreen controls. This resulted in inconsistent locking behavior.

### Changes Made

* Added proper graph lock state management
* Disabled node dragging and node selection while locked
* Disabled canvas panning while locked
* Disabled scroll, pinch, and double-click zoom while locked
* Hid Zoom In, Zoom Out, and Fit View controls while locked
* Hid fullscreen control while locked
* Restored all controls and interactions when unlocked
* Corrected lock/unlock icon behavior

## Related Issue

Closes #79

## Type of Change

* [x] 🐛 Bug fix
* [x] 🎨 UI/UX improvement

## How Has This Been Tested?

* [x] Tested locally using `npm run dev`

### Verified Behavior

* Zoom controls are hidden while locked
* Fullscreen control is unavailable while locked
* Node dragging is disabled while locked
* Canvas panning is disabled while locked
* Double-click zoom is disabled while locked
* All controls and interactions are restored after unlocking

## Screenshots


https://github.com/user-attachments/assets/f0231556-1cf5-4961-b94b-9f10555f8ad9


Attached screen recording demonstrating the fix.

## GSSOC

* [x] This contribution is part of **GirlScript Summer of Code (GSSOC)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a graph lock mode that disables dragging, connecting, selecting, and pan/zoom interactions.
  * Updated the graph controls to use a clearer lock/unlock toggle.
  * Hid fullscreen and other interactive controls while the graph is locked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->