### PR TITLE
🎨 Add global toast notification system with sonner (#155)

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const APP_NAME = "VisualAIze";
@@ -45,6 +46,17 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Toaster
+          position="bottom-right"
+          toastOptions={{
+            style: {
+              background: 'rgba(15, 23, 42, 0.9)',
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+              color: '#e2e8f0',
+              backdropFilter: 'blur(12px)',
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -30,6 +30,7 @@ import CustomNode from '../components/CustomNode';
 import { mergeGraph } from '../utils/mergeGraph';
 import HolographicScene from './HolographicScene';
 import { flushSync } from 'react-dom';
+import { toast } from 'sonner';
 import ErrorModal from './ErrorModal';
 import LoadingCore from './LoadingCore';
 
@@ -626,20 +627,22 @@ function EditorContent({ onBack }: EditorProps) {
       recognition.onerror = () => setIsListening(false);
       recognition.onend = () => setIsListening(false);
       recognition.start();
-    } else { alert("Voice control requires Chrome/Edge."); }
+    } else { toast.error("Voice control requires Chrome/Edge."); }
   };
 
   const handleExport = () => {
     if (reactFlowWrapper.current === null) return;
     toPng(reactFlowWrapper.current, { backgroundColor: '#020617' }).then((dataUrl) => {
         const link = document.createElement('a'); link.download = 'visualaize-graph.png'; link.href = dataUrl; link.click();
-    });
+        toast.success('Graph exported as PNG');
+    }).catch(() => toast.error('Failed to export graph'));
   };
 
   const handleCopyCode = () => {
     if (graphData?.code_snippet) {
       navigator.clipboard.writeText(graphData.code_snippet);
       setCopied(true);
+      toast.success('Code copied to clipboard');
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
       copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
     }


### PR DESCRIPTION
Migrates from native `alert()` to a modern toast notification system using `sonner`.

- Installs `sonner` and adds a styled `<Toaster>` in the root layout
- Replaces `alert('Voice control requires Chrome/Edge.')` with `toast.error()`
- Adds success toasts for code copy and PNG export events

Closes #155