### PR TITLE
✨ Make minimap pannable and zoomable (#159)

### DIFF
--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -899,6 +899,8 @@ function EditorContent({ onBack }: EditorProps) {
 
                 {nodes.length > 0 && (
                     <MiniMap
+                      pannable
+                      zoomable
                       className="!border-white/5"
                       nodeColor={(node) => {
                         const label = node.data?.label?.toLowerCase() || '';


### PR DESCRIPTION
Enables `pannable` and `zoomable` props on the `MiniMap` so users can click and drag the viewport bounding box to pan around large diagrams quickly.

Closes #159