### PR TITLE
🎨 Add Animated Data Flow Edges with play/pause (#161)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -63,6 +63,12 @@ body {
   border-radius: inherit;
 }
 
+@keyframes edgeDashFlow {
+  to {
+    stroke-dashoffset: -10;
+  }
+}
+
 /* ReactFlow built-in controls panel — targets buttons we cannot Tailwind-patch */
 .react-flow__controls-button:focus-visible {
   position: relative !important;

--- a/frontend/src/components/AnimatedEdge.tsx
+++ b/frontend/src/components/AnimatedEdge.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import React from 'react';
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getBezierPath,
+  useReactFlow,
+  type EdgeProps,
+  type Edge,
+} from 'reactflow';
+
+interface AnimatedEdgeData {
+  animated?: boolean;
+}
+
+export default function AnimatedEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  selected,
+  label,
+  data,
+}: EdgeProps<AnimatedEdgeData>) {
+  const isAnimating = data?.animated !== false;
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const midX = (sourceX + targetX) / 2;
+  const midY = (sourceY + targetY) / 2;
+
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        style={{
+          strokeWidth: selected ? 2.5 : 1.5,
+          stroke: selected
+            ? 'rgba(99, 102, 241, 0.9)'
+            : 'rgba(99, 102, 241, 0.35)',
+          strokeDasharray: isAnimating ? '6 4' : 'none',
+          animation: isAnimating ? 'edgeDashFlow 0.8s linear infinite' : 'none',
+        }}
+      />
+
+      {isAnimating && (
+        <circle r={3} fill="#818cf8" opacity={0.8}>
+          <animateMotion dur="2s" repeatCount="indefinite" path={edgePath} />
+        </circle>
+      )}
+
+      {isAnimating && (
+        <circle r={2} fill="#a78bfa" opacity={0.6}>
+          <animateMotion dur="2s" repeatCount="indefinite" path={edgePath} begin="0.5s" />
+        </circle>
+      )}
+
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              background: 'rgba(15, 23, 42, 0.9)',
+              border: '1px solid rgba(99, 102, 241, 0.2)',
+              borderRadius: 4,
+              padding: '2px 8px',
+              fontSize: 10,
+              fontWeight: 600,
+              color: '#93c5fd',
+              letterSpacing: '0.5px',
+              pointerEvents: 'none',
+              whiteSpace: 'nowrap',
+              zIndex: 10,
+            }}
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -27,6 +27,7 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import CustomNode from '../components/CustomNode';
+import AnimatedEdge from '../components/AnimatedEdge';
 import { mergeGraph } from '../utils/mergeGraph';
 import HolographicScene from './HolographicScene';
 import { flushSync } from 'react-dom';
@@ -273,6 +274,7 @@ function EditorContent({ onBack }: EditorProps) {
   const [isChatting, setIsChatting] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isRefineMode, setIsRefineMode] = useState(false);
+  const [isEdgeAnimating, setIsEdgeAnimating] = useState(true);
   const clientId = useRef(crypto.randomUUID());
   const roomId = useRef("room_1");
   const [errorState, setErrorState] = useState<{
@@ -313,7 +315,7 @@ function EditorContent({ onBack }: EditorProps) {
     custom: CustomNode,
   }), []);
 
-  const edgeTypes = useMemo(() => ({}), []);
+  const edgeTypes = useMemo(() => ({ animated: AnimatedEdge }), []);
 
   const onNodesChange: OnNodesChange = useCallback((changes) => {
     setNodes((nds) => {
@@ -441,30 +443,17 @@ function EditorContent({ onBack }: EditorProps) {
         source: e.source,
         target: e.target,
         label: e.label,
-        type: 'smoothstep',
+        type: 'animated',
+        data: { animated: isEdgeAnimating },
         markerEnd: {
           type: MarkerType.ArrowClosed,
-          color: 'rgba(59, 130, 246, 0.7)',
-          width: 12,
-          height: 12
+          color: 'rgba(99, 102, 241, 0.6)',
+          width: 10,
+          height: 10
         },
         style: {
-          stroke: 'rgba(59, 130, 246, 0.4)',
+          stroke: 'rgba(99, 102, 241, 0.3)',
           strokeWidth: 1.5,
-          transition: 'stroke 0.3s ease'
-        },
-        labelStyle: {
-          fill: '#93c5fd',
-          fontWeight: 600,
-          fontSize: 10,
-          letterSpacing: '0.5px'
-        },
-        labelBgPadding: [8, 4],
-        labelBgBorderRadius: 6,
-        labelBgStyle: {
-          fill: 'rgba(15, 23, 42, 0.9)',
-          stroke: 'rgba(59, 130, 246, 0.2)',
-          strokeWidth: 1
         },
       }));
 
@@ -809,6 +798,24 @@ function EditorContent({ onBack }: EditorProps) {
                     {isSidebarOpen ? <PanelRightClose size={14} aria-hidden="true" /> : <PanelRightOpen size={14} aria-hidden="true" />}
                     {isSidebarOpen ? 'CLOSE PANEL' : 'OPEN PANEL'}
                  </button>
+             )}
+
+             {graphData && (
+               <button
+                 onClick={() => {
+                   setIsEdgeAnimating(!isEdgeAnimating);
+                   setEdges(eds => eds.map(e => ({ ...e, data: { ...e.data, animated: !isEdgeAnimating } })));
+                 }}
+                 className={`focus-ring flex items-center gap-2 px-3 py-1 rounded-full border text-xs transition-all shadow-lg ${
+                   isEdgeAnimating
+                     ? 'bg-indigo-600/80 border-indigo-500/50 text-white'
+                     : 'bg-slate-800/80 border-white/10 text-slate-300 hover:bg-blue-600 hover:text-white'
+                 }`}
+                 title={isEdgeAnimating ? 'Pause edge animation' : 'Play edge animation'}
+                 aria-label={isEdgeAnimating ? 'Pause edge animation' : 'Play edge animation'}
+               >
+                 {isEdgeAnimating ? <Zap size={14} /> : <Zap size={14} className="opacity-50" />}
+               </button>
              )}
           </div>
         </div>


### PR DESCRIPTION
Creates a custom React Flow edge component with animated particle flow effects:

- Animated dashed edge lines with moving dots along the bezier path
- Play/pause toggle button in the toolbar
- Edge labels rendered with EdgeLabelRenderer
- Works with existing edge data structure

Closes #161