### PR TITLE
Feat: Architectural Diff View (#166)

### DIFF
--- a/frontend/src/components/CustomNode.tsx
+++ b/frontend/src/components/CustomNode.tsx
@@ -1,14 +1,13 @@
 import React, { memo } from 'react';
 import { Handle, Position } from 'reactflow';
-import { Cpu, Database, Activity, ArrowRightCircle } from 'lucide-react';
+import { Cpu, Database, Activity, ArrowRightCircle, Plus, Minus } from 'lucide-react';
 
 interface CustomNodeProps {
-  data: { label?: string };
+  data: { label?: string; _diffStatus?: 'added' | 'removed' | 'unchanged' };
   selected?: boolean;
 }
 
 const CustomNode = ({ data, selected }: CustomNodeProps) => {
-  // 1. Auto-detect the icon based on the text label
   let Icon = Activity;
   let glowColor = "shadow-blue-500/50";
   let borderColor = "border-blue-400/30";
@@ -25,15 +24,31 @@ const CustomNode = ({ data, selected }: CustomNodeProps) => {
     borderColor = "border-purple-400/50";
   }
 
+  const diffStatus = data?._diffStatus;
+  const isDiff = diffStatus === 'added' || diffStatus === 'removed';
+  let diffBadgeIcon = null;
+  let diffGlow = '';
+  let diffBorderColor = '';
+  if (diffStatus === 'added') {
+    diffBadgeIcon = <Plus size={10} strokeWidth={3} />;
+    diffGlow = 'shadow-emerald-500/40';
+    diffBorderColor = 'border-emerald-400/60';
+  } else if (diffStatus === 'removed') {
+    diffBadgeIcon = <Minus size={10} strokeWidth={3} />;
+    diffGlow = 'shadow-red-500/40';
+    diffBorderColor = 'border-red-400/60';
+  }
+
   return (
     <div 
       className={`
         relative min-w-[160px] px-4 py-3 rounded-xl 
         backdrop-blur-2xl transition-all duration-300
         border hover:border-white/50
+        ${diffStatus === 'added' ? 'bg-emerald-950/40' : diffStatus === 'removed' ? 'bg-red-950/40' : ''}
         ${selected 
           ? `bg-slate-950/90 border-white ${glowColor} shadow-[0_8px_32px_rgba(0,0,0,0.5)] scale-105` 
-          : `bg-slate-900/60 ${borderColor} hover:bg-slate-800/80 hover:shadow-lg hover:-translate-y-0.5`
+          : isDiff ? `bg-slate-900/60 ${diffBorderColor} ${diffGlow}` : `bg-slate-900/60 ${borderColor} hover:bg-slate-800/80 hover:shadow-lg hover:-translate-y-0.5`
         }
       `}
     >
@@ -56,12 +71,22 @@ const CustomNode = ({ data, selected }: CustomNodeProps) => {
         </div>
         
         <div className="flex flex-col">
-          <span className="text-[10px] uppercase tracking-widest text-slate-400 font-bold">State</span>
+          <span className="text-[10px] uppercase tracking-widest text-slate-400 font-bold">
+            {diffStatus === 'added' ? 'Added' : diffStatus === 'removed' ? 'Removed' : 'State'}
+          </span>
           <span className={`text-sm font-semibold tracking-wide ${selected ? 'text-white' : 'text-slate-100'}`}>
             {data?.label || "Unknown Node"}
           </span>
         </div>
       </div>
+
+      {isDiff && (
+        <div className={`absolute -top-2 -right-2 w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold text-black shadow-lg ${
+          diffStatus === 'added' ? 'bg-emerald-400' : 'bg-red-400'
+        }`}>
+          {diffBadgeIcon}
+        </div>
+      )}
 
       {/* Output Connector (Bottom) */}
       <Handle 

--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -10,7 +10,8 @@ import {
   Activity, BookOpen, PlayCircle, Layers, Code, Copy, Check, Zap,
   Globe, Mic, Download, ChevronDown, MessageSquare, Send, Paperclip,
   PanelRightClose, PanelRightOpen, AlertTriangle, ArrowRight, X, RefreshCw,
-  Maximize2, Minimize2, ZoomIn, ZoomOut, Maximize, Lock, Unlock, History
+  Maximize2, Minimize2, ZoomIn, ZoomOut, Maximize, Lock, Unlock, History,
+  Plus, Minus
 } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
@@ -287,6 +288,9 @@ function EditorContent({ onBack }: EditorProps) {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [savedHistory, setSavedHistory] = useState<SavedDiagram[]>([]);
+  const [diffMode, setDiffMode] = useState(false);
+  const [previousNodes, setPreviousNodes] = useState<Node[]>([]);
+  const [previousEdges, setPreviousEdges] = useState<Edge[]>([]);
 
   useEffect(() => {
     setSavedHistory(getHistory());
@@ -368,6 +372,10 @@ function EditorContent({ onBack }: EditorProps) {
 
   const generateGraph = async (text: string) => {
     if (!text || isGenerating) return;
+    if (isRefineMode && nodes.length > 0) {
+      setPreviousNodes(nodes);
+      setPreviousEdges(edges);
+    }
     setIsGenerating(true);
     setPrompt(text);
     setGraphData(null);
@@ -469,18 +477,48 @@ function EditorContent({ onBack }: EditorProps) {
       }));
 
       const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(rawNodes, rawEdges);
-      
-      const merged = mergeGraph(
-        { nodes: layoutedNodes, edges: layoutedEdges },
-        { nodes: getNodes(), edges: getEdges() },
-        isRefineMode
-      );
-      flushSync(() => {
-        setNodes(merged.nodes);
-        setEdges(merged.edges);
-      });
 
-      const newEntry = saveToHistory(text, data, merged.nodes, merged.edges);
+      let finalNodes: Node[] = layoutedNodes;
+      let finalEdges: Edge[] = layoutedEdges;
+
+      if (isRefineMode && previousNodes.length > 0) {
+        const prevIds = new Set(previousNodes.map(n => n.id));
+        const newIds = new Set(layoutedNodes.map(n => n.id));
+        const removedNodes = previousNodes.filter(n => !newIds.has(n.id));
+
+        const diffNodes = [
+          ...layoutedNodes.map(n => ({
+            ...n,
+            data: { ...n.data, _diffStatus: prevIds.has(n.id) ? ('unchanged' as const) : ('added' as const) }
+          })),
+          ...removedNodes.map(n => ({
+            ...n,
+            data: { ...n.data, _diffStatus: 'removed' as const },
+            style: { ...n.style, opacity: 0.5 }
+          }))
+        ];
+        finalNodes = diffNodes;
+        finalEdges = layoutedEdges;
+        flushSync(() => {
+          setNodes(diffNodes);
+          setEdges(layoutedEdges);
+        });
+        setDiffMode(true);
+      } else {
+        const merged = mergeGraph(
+          { nodes: layoutedNodes, edges: layoutedEdges },
+          { nodes: getNodes(), edges: getEdges() },
+          isRefineMode
+        );
+        finalNodes = merged.nodes;
+        finalEdges = merged.edges;
+        flushSync(() => {
+          setNodes(merged.nodes);
+          setEdges(merged.edges);
+        });
+      }
+
+      const newEntry = saveToHistory(text, data, finalNodes, finalEdges);
       if (newEntry) {
         setSavedHistory(prev => [newEntry, ...prev].slice(0, 20));
       }
@@ -824,6 +862,42 @@ function EditorContent({ onBack }: EditorProps) {
             ))}
           </div>
         </div>
+
+        {/* Diff mode overlay */}
+        {diffMode && (
+          <div className="absolute top-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-5 py-2 rounded-full bg-slate-900/90 backdrop-blur-xl border border-white/10 shadow-2xl pointer-events-auto">
+            <span className="text-xs font-bold text-white tracking-wider">DIFF MODE</span>
+            <div className="flex items-center gap-2 text-[10px]">
+              <span className="flex items-center gap-1 text-emerald-400"><Plus size={12} /> New</span>
+              <span className="flex items-center gap-1 text-red-400"><Minus size={12} /> Removed</span>
+            </div>
+            <div className="w-px h-4 bg-white/10" />
+            <button
+              onClick={() => {
+                setDiffMode(false);
+                setNodes(nds => nds.filter(n => n.data?._diffStatus !== 'removed').map(n => ({ ...n, data: { label: n.data?.label }, style: { background: 'transparent', border: 'none', boxShadow: 'none', width: 'auto' } })));
+                setPreviousNodes([]);
+                setPreviousEdges([]);
+                setGraphData(graphData);
+              }}
+              className="px-3 py-1 rounded-full bg-emerald-500 text-white text-xs font-bold hover:bg-emerald-400 transition-colors"
+            >
+              Accept
+            </button>
+            <button
+              onClick={() => {
+                setDiffMode(false);
+                flushSync(() => { setNodes(previousNodes); setEdges(previousEdges); });
+                setPreviousNodes([]);
+                setPreviousEdges([]);
+                requestAnimationFrame(() => fitView({ padding: 0.15, duration: 500 }));
+              }}
+              className="px-3 py-1 rounded-full bg-red-500/20 text-red-400 text-xs font-bold hover:bg-red-500/30 transition-colors border border-red-500/30"
+            >
+              Reject
+            </button>
+          </div>
+        )}
 
         {/* Focus mode toggle */}
         <button


### PR DESCRIPTION
**Implements:** Architectural Diff View (Issue #166)

### What
Shows a visual diff when refining a graph. New nodes appear in green with a + badge, removed nodes appear in red (semi-transparent) with a - badge. Users can Accept or Reject changes.

### Changes
- **GraphEditor diff mode**: Saves graph state before refine fetch; after response, computes added vs removed nodes; renders with `_diffStatus` annotations
- **CustomNode**: Renders diff badges (Plus/Minus icons) with color-coded backgrounds (emerald for added, red for removed) and adjusted border/glow
- **Diff overlay**: Centered top bar showing legend (New/Removed) with Accept (commit changes) and Reject (restore previous state) buttons
- Accept removes deleted nodes and resets styling; Reject recovers previous nodes/edges

### Testing
- `npx tsc --noEmit` shows only pre-existing jest type errors
- `git diff --check` shows no trailing whitespace