### PR TITLE
Add toggle button for edge labels in Graph Editor

### DIFF
--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -10,7 +10,7 @@ import {
   Activity, BookOpen, PlayCircle, Layers, Code, Copy, Check, Zap,
   Globe, Mic, Download, ChevronDown, MessageSquare, Send, Paperclip,
   PanelRightClose, PanelRightOpen, AlertTriangle, ArrowRight, X, RefreshCw,
-  Maximize2, Minimize2, ZoomIn, ZoomOut, Maximize, Lock, Unlock, History
+  Maximize2, Minimize2, ZoomIn, ZoomOut, Maximize, Lock, Unlock, History, Eye, EyeOff
 } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
@@ -257,6 +257,8 @@ const ZeroState = ({ onSelect }: { onSelect: (text: string) => void }) => {
 function EditorContent({ onBack }: EditorProps) {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
+  const [showEdgeLabels, setShowEdgeLabels] = useState(true);
+
   const [viewport, setViewport] = useState({ x: 0, y: 0, zoom: 1 });
   const [prompt, setPrompt] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
@@ -440,7 +442,7 @@ function EditorContent({ onBack }: EditorProps) {
         id: `e-${i}`,
         source: e.source,
         target: e.target,
-        label: e.label,
+        label: showEdgeLabels ? e.label : '',
         type: 'smoothstep',
         markerEnd: {
           type: MarkerType.ArrowClosed,
@@ -670,10 +672,15 @@ function EditorContent({ onBack }: EditorProps) {
   }, [visibleNodes]);
 
   const filteredEdges = useMemo(() => {
-    return edges.filter(
-      (e) => visibleNodeIds.has(e.source) && visibleNodeIds.has(e.target)
-    );
-  }, [edges, visibleNodeIds]);
+    return edges
+      .filter(
+        (e) => visibleNodeIds.has(e.source) && visibleNodeIds.has(e.target)
+      )
+      .map((e) => ({
+        ...e,
+        label: showEdgeLabels ? e.label : '',
+      }));
+  }, [edges, visibleNodeIds, showEdgeLabels]);
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
@@ -893,6 +900,17 @@ function EditorContent({ onBack }: EditorProps) {
                       aria-label="Toggle interactive"
                     >
                       <Lock size={14} />
+                    </ControlButton>
+                    <ControlButton
+                      onClick={() => setShowEdgeLabels(prev => !prev)}
+                      title="Toggle Edge Labels"
+                      aria-label="Toggle edge labels"
+                    >
+                      {showEdgeLabels ? (
+                        <Eye size={14} />
+                      ) : (
+                        <EyeOff size={14} />
+                      )}
                     </ControlButton>
                   </Controls>
                 )}


### PR DESCRIPTION
## Description

Added a control button in the Graph Editor that allows users to toggle edge labels on and off.

## Related Issue

Closes #157

## Type of Change

* [x] New feature (non-breaking change that adds functionality)

## Changes Made

* Added `showEdgeLabels` state
* Added a new control button for toggling edge labels
* Updated edge rendering logic to conditionally display labels
* Updated filtered edges to react to label visibility changes

## Testing

* Ran the application locally
* Generated workflow diagrams
* Verified edge labels are visible by default
* Verified clicking the toggle button hides all edge labels
* Verified clicking again restores edge labels



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a graph editor control to show or hide edge labels. Labels are enabled by default, and you can disable them to reduce visual clutter.
  * Edge label visibility now updates automatically with the currently visible nodes, so labels only appear on relevant edges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->