### PR TITLE
Add Download Button for Generated Code Snippets (#130)

### DIFF
--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -645,6 +645,34 @@ function EditorContent({ onBack }: EditorProps) {
     }
   };
 
+  const handleDownloadCode = () => {
+    if (!graphData?.code_snippet) return;
+
+    const blob = new Blob(
+      [graphData.code_snippet],
+      { type: "text/plain" }
+    );
+
+    const url = URL.createObjectURL(blob);
+
+    const extensionMap: Record<string, string> = {
+      Python: "py",
+      JavaScript: "js",
+      "C++": "cpp",
+      Java: "java",
+    };
+
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `generated-code.${extensionMap[codeLanguage]}`;
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(url);
+  };
+
   const showBackground = nodes.length === 0;
 
   const { x, y, zoom } = getViewport();
@@ -1056,9 +1084,23 @@ function EditorContent({ onBack }: EditorProps) {
                               <RefreshCw size={14}/>
                             </button>
                       </div>
-                      <button onClick={handleCopyCode} className="focus-ring flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-xs font-bold transition-colors">
-                        {copied ? <Check size={14} /> : <Copy size={14} />} {copied ? 'COPIED' : 'COPY'}
-                      </button>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={handleCopyCode}
+                          className="focus-ring flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-xs font-bold transition-colors"
+                        >
+                          {copied ? <Check size={14} /> : <Copy size={14} />}
+                          {copied ? 'COPIED' : 'COPY'}
+                        </button>
+
+                        <button
+                          onClick={handleDownloadCode}
+                          className="focus-ring flex items-center gap-2 px-3 py-1.5 rounded-lg bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 text-xs font-bold transition-colors"
+                        >
+                          <Download size={14} />
+                          DOWNLOAD
+                        </button>
+                      </div>
                     </div>
                     <div className="flex-1 rounded-xl bg-black/50 border border-white/10 p-4 overflow-x-auto relative">
                         {isRegeneratingCode && <div className="absolute inset-0 bg-black/80 flex items-center justify-center text-blue-400 text-xs font-bold animate-pulse z-10">REWRITING...</div>}

--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -662,9 +662,11 @@ function EditorContent({ onBack }: EditorProps) {
       Java: "java",
     };
 
+    const extension = extensionMap[codeLanguage] ?? "txt";
+
     const link = document.createElement("a");
     link.href = url;
-    link.download = `generated-code.${extensionMap[codeLanguage]}`;
+    link.download = `generated-code.${extension}`;
 
     document.body.appendChild(link);
     link.click();


### PR DESCRIPTION
Closes #130

## Type of Change

* [x] New feature (non-breaking change that adds functionality)

## Changes Made

* Added a Download button next to the existing Copy button in the Code tab.
* Implemented code download functionality using Blob and URL.createObjectURL().
* Added language-to-file-extension mapping for generated code files.
* Supported:

  * Python → .py
  * JavaScript → .js
  * C++ → .cpp
  * Java → .java
* Ensured downloaded files use appropriate extensions based on the selected language.

## Testing

* Verified the Download button appears next to the Copy button.
* Generated a Binary Search Tree example.
* Successfully downloaded the generated code as:

  * generated-code.py
* Confirmed the downloaded file contains the generated code snippet.

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added download functionality to export code snippets with appropriate file extensions based on programming language (Python, JavaScript, C++, Java)
  * Enhanced code panel toolbar with explicit COPY and DOWNLOAD buttons
  * Added visual feedback for copy action with button state change to indicate successful copying

<!-- end of auto-generated comment: release notes by coderabbit.ai -->