### PR TITLE
security: add shared-secret auth and CORS allowlist to /generate (#249)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,14 @@
 # Get your key at https://aistudio.google.com/app/apikey
 GEMINI_API_KEY=your_gemini_api_key_here
 
+# Shared secret required to call protected endpoints (e.g. /generate).
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Must match NEXT_PUBLIC_INTERNAL_SECRET below.
+INTERNAL_API_SECRET=your_long_random_shared_secret_here
+
+# Comma-separated list of origins allowed to call the backend.
+ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
 # --- FRONTEND CONFIG ---
 NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_INTERNAL_SECRET=your_long_random_shared_secret_here

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,11 @@
 # Google Gemini API Key
 # Get yours at: https://makersuite.google.com/app/apikey
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Shared secret required to call protected endpoints (e.g. /generate).
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Must match NEXT_PUBLIC_INTERNAL_SECRET on the frontend.
+INTERNAL_API_SECRET=your_long_random_shared_secret_here
+
+# Comma-separated list of origins allowed to call this backend.
+ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,8 +4,9 @@ import sys
 import re
 import time
 import hashlib
+import hmac
 import logging
-from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
@@ -87,6 +88,34 @@ def _build_redis_client():
 # Initialize cache — Redis preferred, InMemoryCache as safe fallback
 _redis_client = _build_redis_client()
 cache = _redis_client if _redis_client is not None else InMemoryCache()
+
+# --- INTERNAL AUTH CONFIG ---
+# Shared-secret header required to call sensitive AI-generation endpoints.
+# The frontend is the only intended caller; this prevents unauthenticated
+# third parties from discovering the backend URL and driving up the Gemini
+# bill for free (see Issue: Security - /api/generate has no auth check).
+INTERNAL_API_SECRET = os.getenv("INTERNAL_API_SECRET", "")
+if not INTERNAL_API_SECRET:
+    logger.warning(
+        "⚠️ INTERNAL_API_SECRET is not set. The /generate endpoint will reject "
+        "all requests until this is configured. Set INTERNAL_API_SECRET in "
+        "your environment to a long random value shared with the frontend."
+    )
+
+async def verify_internal(x_internal_secret: str = Header(default="")) -> None:
+    """FastAPI dependency gating sensitive endpoints behind a shared secret.
+
+    Raises:
+        HTTPException 503: INTERNAL_API_SECRET is not configured server-side.
+        HTTPException 403: The provided X-Internal-Secret header is missing or wrong.
+    """
+    if not INTERNAL_API_SECRET:
+        raise HTTPException(
+            status_code=503,
+            detail="INTERNAL_AUTH_NOT_CONFIGURED: Server is missing INTERNAL_API_SECRET.",
+        )
+    if not x_internal_secret or not hmac.compare_digest(x_internal_secret, INTERNAL_API_SECRET):
+        raise HTTPException(status_code=403, detail="Forbidden")
 
 # --- RATE LIMITER CONFIG ---
 if _redis_client is not None:
@@ -223,9 +252,23 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 
 
+# Restrict cross-origin calls to the known frontend deployment(s).
+# ALLOWED_ORIGINS is a comma-separated list; falls back to localhost dev
+# origins if unset so local development keeps working out of the box.
+_allowed_origins_env = os.getenv("ALLOWED_ORIGINS", "")
+if _allowed_origins_env:
+    ALLOWED_ORIGINS = [o.strip() for o in _allowed_origins_env.split(",") if o.strip()]
+else:
+    ALLOWED_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:3000"]
+    logger.warning(
+        "⚠️ ALLOWED_ORIGINS is not set. Falling back to localhost dev origins only: %s. "
+        "Set ALLOWED_ORIGINS in production to your deployed frontend URL.",
+        ALLOWED_ORIGINS,
+    )
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -356,7 +399,7 @@ All backslashes in code_snippet or strings MUST be properly double-escaped (e.g.
 
 _GENERIC_ERROR = "An unexpected error occurred. Please try again."
 
-@app.post("/generate")
+@app.post("/generate", dependencies=[Depends(verify_internal)])
 @limiter.limit("10/minute")
 async def generate_graph(request: Request, payload: GraphRequest):
     """

--- a/backend/test_server.py
+++ b/backend/test_server.py
@@ -16,10 +16,15 @@ mock_genai = MagicMock()
 sys.modules["google.generativeai"] = mock_genai
 
 import main
-from main import app, ChatRequest, CodeRequest, GraphRequest
+from main import app, ChatRequest, CodeRequest, GraphRequest, verify_internal
 
 # Create the test client
 app.state.limiter.enabled = False
+
+# Existing functional tests below don't exercise auth — bypass the shared-secret
+# dependency here so they keep testing behavior, not the auth layer.
+# Auth itself is covered explicitly by the test_internal_auth_* tests further down.
+app.dependency_overrides[verify_internal] = lambda: None
 client = TestClient(app)
 
 
@@ -174,3 +179,82 @@ def test_generate_no_api_key_returns_503():
         assert response.status_code == 503
     finally:
         main.GENAI_KEY = original_key
+
+
+# --- INTERNAL AUTH TESTS ---
+# These temporarily remove the verify_internal override (shared across all
+# TestClient instances, since they wrap the same `app`) so the real auth
+# logic runs, then restore the override so later tests keep bypassing auth.
+
+import contextlib
+
+
+@contextlib.contextmanager
+def _real_auth_enabled():
+    app.dependency_overrides.pop(verify_internal, None)
+    try:
+        yield
+    finally:
+        app.dependency_overrides[verify_internal] = lambda: None
+
+
+def test_internal_auth_rejects_missing_header():
+    """POST /generate without X-Internal-Secret must return 403 (once configured)."""
+    original_secret = main.INTERNAL_API_SECRET
+    try:
+        main.INTERNAL_API_SECRET = "test-secret-value"
+        with _real_auth_enabled():
+            response = client.post("/generate", json={"prompt": "test"})
+        assert response.status_code == 403
+    finally:
+        main.INTERNAL_API_SECRET = original_secret
+
+
+def test_internal_auth_rejects_wrong_secret():
+    """POST /generate with an incorrect X-Internal-Secret must return 403."""
+    original_secret = main.INTERNAL_API_SECRET
+    try:
+        main.INTERNAL_API_SECRET = "test-secret-value"
+        with _real_auth_enabled():
+            response = client.post(
+                "/generate",
+                json={"prompt": "test"},
+                headers={"X-Internal-Secret": "wrong-value"},
+            )
+        assert response.status_code == 403
+    finally:
+        main.INTERNAL_API_SECRET = original_secret
+
+
+@patch.object(main, "get_smart_response")
+def test_internal_auth_accepts_correct_secret(mock_ai):
+    """POST /generate with the correct X-Internal-Secret must be allowed through."""
+    mock_ai.return_value = json.dumps(MOCK_GRAPH)
+    original_secret = main.INTERNAL_API_SECRET
+    try:
+        main.INTERNAL_API_SECRET = "test-secret-value"
+        with patch("main.GENAI_KEY", "mock_key_for_testing"), _real_auth_enabled():
+            response = client.post(
+                "/generate",
+                json={"prompt": "test"},
+                headers={"X-Internal-Secret": "test-secret-value"},
+            )
+        assert response.status_code == 200
+    finally:
+        main.INTERNAL_API_SECRET = original_secret
+
+
+def test_internal_auth_returns_503_when_not_configured():
+    """POST /generate must return 503 if INTERNAL_API_SECRET is unset server-side."""
+    original_secret = main.INTERNAL_API_SECRET
+    try:
+        main.INTERNAL_API_SECRET = ""
+        with _real_auth_enabled():
+            response = client.post(
+                "/generate",
+                json={"prompt": "test"},
+                headers={"X-Internal-Secret": "anything"},
+            )
+        assert response.status_code == 503
+    finally:
+        main.INTERNAL_API_SECRET = original_secret

--- a/frontend/src/components/GraphEditor.tsx
+++ b/frontend/src/components/GraphEditor.tsx
@@ -72,6 +72,9 @@ interface WindowWithSpeech extends Window {
 }
 
 const BACKEND_URL = "https://visualaize-backend.onrender.com";
+// Shared secret sent with requests to protected backend endpoints (e.g. /generate).
+// Must match INTERNAL_API_SECRET configured on the backend.
+const INTERNAL_API_SECRET = process.env.NEXT_PUBLIC_INTERNAL_SECRET ?? "";
 
 const glassControlsStyle = `
   .react-flow__panel .react-flow__controls {
@@ -433,7 +436,10 @@ function EditorContent({ onBack }: EditorProps) {
     try {
       const res = await fetch(`${BACKEND_URL}/generate`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Internal-Secret': INTERNAL_API_SECRET,
+        },
         body: JSON.stringify({ prompt: text }),
       });
 


### PR DESCRIPTION
## Summary
Adds authentication and origin restriction to the `POST /generate` endpoint, which previously accepted requests from any caller with no auth check and a wide-open CORS policy (`allow_origins=["*"]`).

## Problem Statement
Anyone who discovered the backend URL (trivially visible in browser Network tab requests) could call `/generate` directly and consume the deployer's Gemini API quota/billing with no authentication, JWT, or origin restriction in place.

```bash
curl -X POST http://backend-url/generate \
  -H "Content-Type: application/json" \
  -d '{"prompt": "create a DFA for a*b"}'
# Returns a full Gemini-powered response — no auth challenge
```

## Solution Overview
Two complementary layers of protection, matching the issue's proposed fix plus a CORS tightening:

1. **Shared-secret header auth** — `verify_internal()` FastAPI dependency compares the `X-Internal-Secret` request header against `INTERNAL_API_SECRET` (server env var) using `hmac.compare_digest` (constant-time, avoids timing attacks). Applied to `POST /generate` via `dependencies=[Depends(verify_internal)]`.
2. **CORS allowlist** — Replaced `allow_origins=["*"]` with a configurable `ALLOWED_ORIGINS` env var (comma-separated), defaulting to localhost dev origins instead of wildcard.

### Fail-safe behavior
- `INTERNAL_API_SECRET` not configured server-side → **503** (fails closed, doesn't silently allow all traffic)
- Missing or incorrect `X-Internal-Secret` header → **403**
- Correct header → request proceeds normally

## Frontend Changes
`GraphEditor.tsx` now sends `X-Internal-Secret: ${NEXT_PUBLIC_INTERNAL_SECRET}` on the `/generate` fetch call. New env vars documented in both `.env.example` (root) and `backend/.env.example`.

## Testing
Added 4 new tests to `backend/test_server.py`:
- `test_internal_auth_rejects_missing_header` — no header → 403
- `test_internal_auth_rejects_wrong_secret` — wrong header value → 403
- `test_internal_auth_accepts_correct_secret` — correct header → 200
- `test_internal_auth_returns_503_when_not_configured` — secret unset → 503

Existing endpoint-behavior tests bypass the new dependency via `app.dependency_overrides` so they continue testing endpoint logic rather than auth (auth has its own dedicated tests).

**Verified locally:**
```
18 passed, 1 failed in 2.03s
```
The 1 failure (`test_generate_no_api_key_returns_503`) is **pre-existing on master** — confirmed via `git stash` comparison before/after this change, same failure both times. Unrelated to this PR.

- `flake8 main.py --select=E9,F63,F7,F82` → 0 errors
- Frontend `npx tsc --noEmit` → no new type errors introduced
- Frontend `npm run build` → compiles successfully

## Files Changed
- `backend/main.py` — auth dependency, CORS allowlist, applied to `/generate`
- `backend/test_server.py` — 4 new auth tests + dependency override for existing tests
- `.env.example`, `backend/.env.example` — document `INTERNAL_API_SECRET`, `ALLOWED_ORIGINS`, `NEXT_PUBLIC_INTERNAL_SECRET`
- `frontend/src/components/GraphEditor.tsx` — send shared-secret header

## Note on Threat Model
Since `X-Internal-Secret` is read from `NEXT_PUBLIC_INTERNAL_SECRET` in a client-rendered component, the secret is visible in the bundled JS to anyone who inspects it — this raises the bar (an attacker must extract it from the bundle rather than just reading the URL) but is not equivalent to true server-side secrecy. A stronger long-term architecture would route `/generate` calls through a Next.js server-side API route that holds the secret server-only. Flagging this tradeoff for maintainer awareness; happy to follow up with that approach if preferred.

Closes #249

GSSoC 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for protected backend requests using a shared secret between the app and server.
  * Added configurable allowed origins for cross-origin access, with safer defaults for local development.

* **Bug Fixes**
  * Requests to the graph generation endpoint now include the required secret header, improving request reliability.
  * The backend now rejects unauthorized or misconfigured requests with clearer access handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->