### PR TITLE
feat: implement LRU eviction for in-memory fallback cache

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ import redis
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
+from collections import OrderedDict
 
 room_users = {}
 
@@ -33,7 +34,7 @@ REDIS_URL = os.getenv("REDIS_URL", "")
 class InMemoryCache:
     """Fallback in-memory cache (TTL-aware, size-bounded) used when Redis is unavailable."""
     def __init__(self, max_size: int = 1000):
-        self._cache: dict = {}
+        self._cache: OrderedDict[str, dict] = OrderedDict()
         self._max_size = max_size
         logger.info("💡 Created in-memory fallback prompt cache (max_size=%d).", max_size)
 
@@ -41,18 +42,33 @@ class InMemoryCache:
         entry = self._cache.get(key)
         if entry is None:
             return None
-        if time.monotonic() < entry['expires_at']:
-            return entry['value']
+        
         # Expired — evict lazily
-        del self._cache[key]
-        return None
+        if time.monotonic() >= entry['expires_at']:
+            del self._cache[key]
+            return None
+        
+        # Mark the entry as recently used to maintain LRU ordering.
+        self._cache.move_to_end(key)
+        
+        return entry['value']
 
     def setex(self, key: str, time_sec: int, value: str) -> None:
+
+        # Refresh existing keys so reinsertion updates their LRU position.
+        self._cache.pop(key, None)
+
         if len(self._cache) >= self._max_size:
-            # Evict oldest 20% to avoid constant full-clears
+            # Evict the least recently used 20% to avoid constant full-clears.
             evict_count = max(1, self._max_size // 5)
-            for k in list(self._cache.keys())[:evict_count]:
-                del self._cache[k]
+            
+            for _ in range(evict_count):
+                if not self._cache:
+                    break
+
+                # Evict the least recently used entries while preserving batch eviction.
+                self._cache.popitem(last=False)
+
         self._cache[key] = {
             'value': value,
             'expires_at': time.monotonic() + time_sec


### PR DESCRIPTION
## Description

- Implemented an LRU (Least Recently Used) eviction policy for the fallback `InMemoryCache` by replacing the insertion-ordered dictionary with `OrderedDict`. The cache continues to preserve its existing TTL semantics, lazy expiration behavior, and size-bounded batch eviction strategy while retaining recently accessed entries.

## Related Issue

- Closes #248 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactor (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔧 Chore (build process, dependencies, etc.)

## Changes Made

- Replaced the underlying cache storage with `collections.OrderedDict` to maintain access order.
- Updated `get()` to move successfully accessed entries to the end of the cache, marking them as most recently used.
- Updated `setex()` to refresh existing keys before capacity checks, ensuring updates do not trigger unnecessary eviction while also refreshing the key's LRU position.
- Replaced FIFO-style batch eviction with `OrderedDict.popitem(last=False)` to evict the least recently used entries while preserving the existing batch eviction strategy.
- Preserved lazy expiration by removing expired entries only when accessed.

## How Has This Been Tested?

- [x] Tested locally (frontend: `npm run dev`, backend: `uvicorn server:app --reload`)
- [x] Verified existing tests still pass (`pytest test_server.py -v` / `npm run build`)
- [ ] Added new tests for the changes

## Checklist

- [x] My code follows the existing code style of the project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary (especially in complex logic)
- [ ] I have updated the documentation if needed
- [x] My changes do not introduce any new warnings or errors
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] All new and existing tests pass locally

## GSSOC

- [x] This contribution is part of **GirlScript Summer of Code (GSSOC)**
- Label: level: intermediate (requires some experience), type: feature, type: performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache behavior so recently used items stay available longer.
  * Expired entries are now cleared more reliably when accessed.
  * When the cache reaches capacity, it now removes the least recently used items first for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->