### PR TITLE
fix: add radix parameter to parseInt calls

### DIFF
--- a/frontend/src/utils/layout.ts
+++ b/frontend/src/utils/layout.ts
@@ -79,7 +79,7 @@ export const getLayoutedElements = (nodes: Node[], edges: Edge[]) => {
 
   let activeRowIndex = 0;
   Object.keys(layers).forEach((key) => {
-    const layerIndex = parseInt(key);
+    const layerIndex = parseInt(key, 10);
     const layerNodes = layers[layerIndex];
     
     if (layerNodes.length === 0) return;


### PR DESCRIPTION
Added radix 10 parameter to parseInt() calls to prevent unexpected octal/hex interpretation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layer index handling during layout corrections for more reliable symmetry and positioning results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->